### PR TITLE
Kerning (padding) between characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `LetterSpacing` enum to allow customizable kerning between characters.
+- `letter_spacing` field to `ImageFontSpriteText` for individual entity customization.
+- Example in `atlased_sprite` to demonstrate `LetterSpacing` usage.
+
+### Changed
+
+- Updated text rendering calculations to account for `letter_spacing`.
+
+### Breaking Changes
+
+- Added `letter_spacing` field to `ImageFontSpriteText`, requiring updates to any initialization of this struct.
+
 ## [0.8.0] - 2025-01-24
 
 ### Added

--- a/examples/atlased_sprite.rs
+++ b/examples/atlased_sprite.rs
@@ -16,7 +16,7 @@ use bevy::prelude::*;
 use bevy::sprite::Anchor;
 use bevy_asset_loader::prelude::AssetCollectionApp as _;
 use bevy_image_font::atlas_sprites::ImageFontSpriteText;
-use bevy_image_font::{ImageFontPlugin, ImageFontText};
+use bevy_image_font::{ImageFontPlugin, ImageFontText, LetterSpacing};
 
 use crate::common::{DemoAssets, FONT_WIDTH, RAINBOW, TEXT};
 
@@ -84,6 +84,17 @@ fn spawn_text(mut commands: Commands, assets: Res<DemoAssets>) {
             40.,
             0.,
         )),
+    ));
+
+    commands.spawn((
+        ImageFontSpriteText::default()
+            .color(tailwind::ZINC_500)
+            .letter_spacing(LetterSpacing::Pixel(2)),
+        ImageFontText::default()
+            .text(TEXT)
+            .font(assets.image_font.clone())
+            .font_height(36.0),
+        Transform::from_translation(Vec3::new(0.5, -40., 0.)),
     ));
 }
 

--- a/src/atlas_sprites.rs
+++ b/src/atlas_sprites.rs
@@ -77,7 +77,9 @@ pub struct ImageFontSpriteText {
     /// The default value is `ScalingMode::Rounded`.
     pub scaling_mode: ScalingMode,
 
-    /// Determines a constant kerning between characters.
+    /// Determines a constant kerning between characters. The spacing is given
+    /// at the font's native height and is scaled along with the font at other
+    /// heights.
     pub letter_spacing: LetterSpacing,
 }
 

--- a/src/atlas_sprites.rs
+++ b/src/atlas_sprites.rs
@@ -358,8 +358,7 @@ fn calculate_text_width(
             sprite_text.letter_spacing,
             sprite_text.scaling_mode,
         );
-        let letter_spacing: f32 = sprite_text.letter_spacing.into();
-        total_width += width + letter_spacing;
+        total_width += width;
     }
     total_width
 }

--- a/src/atlas_sprites.rs
+++ b/src/atlas_sprites.rs
@@ -350,7 +350,7 @@ fn calculate_text_width(
         let rect = layout.textures[image_font.atlas_character_map[&character]];
         let (width, _) =
             compute_dimensions(rect, image_font_text.font_height, max_height, scaling_mode);
-        total_width += width;
+        total_width += width + Into::<f32>::into(image_font_text.letter_spacing);
     }
     total_width
 }

--- a/src/atlas_sprites.rs
+++ b/src/atlas_sprites.rs
@@ -76,6 +76,9 @@ pub struct ImageFontSpriteText {
     ///
     /// The default value is `ScalingMode::Rounded`.
     pub scaling_mode: ScalingMode,
+
+    /// Determines a constant kerning between characters.
+    pub letter_spacing: LetterSpacing,
 }
 
 /// Determines how scaling is applied when calculating the dimensions of a
@@ -192,7 +195,7 @@ pub fn set_up_sprites(
         let scale = calculate_scale(image_font_text.font_height, max_height);
         let total_width = calculate_text_width(
             image_font_text,
-            image_font_sprite_text.scaling_mode,
+            image_font_sprite_text,
             image_font,
             layout,
             &text,
@@ -338,7 +341,7 @@ fn calculate_text_height(
 #[inline]
 fn calculate_text_width(
     image_font_text: &ImageFontText,
-    scaling_mode: ScalingMode,
+    sprite_text: &ImageFontSpriteText,
     image_font: &ImageFont,
     layout: &TextureAtlasLayout,
     text: &filtered_string::FilteredString<'_, &String>,
@@ -352,10 +355,10 @@ fn calculate_text_width(
             rect,
             image_font_text.font_height,
             max_height,
-            image_font_text.letter_spacing,
-            scaling_mode,
+            sprite_text.letter_spacing,
+            sprite_text.scaling_mode,
         );
-        let letter_spacing: f32 = image_font_text.letter_spacing.into();
+        let letter_spacing: f32 = sprite_text.letter_spacing.into();
         total_width += width + letter_spacing;
     }
     total_width
@@ -490,7 +493,7 @@ fn update_existing_sprites(
             rect,
             font_text.font_height,
             max_height,
-            font_text.letter_spacing,
+            sprite_text.letter_spacing,
             sprite_text.scaling_mode,
         );
 
@@ -743,7 +746,7 @@ fn add_missing_sprites(
                 rect,
                 image_font_text.font_height,
                 max_height,
-                image_font_text.letter_spacing,
+                sprite_text.letter_spacing,
                 sprite_text.scaling_mode,
             );
 

--- a/src/atlas_sprites.rs
+++ b/src/atlas_sprites.rs
@@ -21,7 +21,7 @@ use bevy::prelude::*;
 use bevy::sprite::Anchor;
 use derive_setters::Setters;
 
-use crate::filtered_string;
+use crate::{filtered_string, LetterSpacing};
 use crate::{sync_texts_with_font_changes, ImageFont, ImageFontSet, ImageFontText};
 
 /// Internal plugin for conveniently organizing the code related to this
@@ -349,7 +349,13 @@ fn calculate_text_width(
     for character in text.filtered_chars() {
         let rect = layout.textures[image_font.atlas_character_map[&character]];
         let (width, _) =
-            compute_dimensions(rect, image_font_text.font_height, max_height, scaling_mode);
+            compute_dimensions(
+                rect,
+                image_font_text.font_height,
+                max_height,
+                image_font_text.letter_spacing,
+                scaling_mode
+            );
         total_width += width + Into::<f32>::into(image_font_text.letter_spacing);
     }
     total_width
@@ -484,6 +490,7 @@ fn update_existing_sprites(
             rect,
             font_text.font_height,
             max_height,
+            font_text.letter_spacing,
             sprite_text.scaling_mode,
         );
 
@@ -551,9 +558,10 @@ fn compute_dimensions(
     rect: URect,
     font_height: Option<f32>,
     max_height: u32,
+    letter_spacing: LetterSpacing,
     scaling_mode: ScalingMode,
 ) -> (f32, f32) {
-    let width = rect.width() as f32;
+    let width = rect.width() as f32 + Into::<f32>::into(letter_spacing);
     let height = rect.height() as f32;
     let max_height = max_height as f32;
     font_height.map_or((width, height), |fh| match scaling_mode {
@@ -734,6 +742,7 @@ fn add_missing_sprites(
                 rect,
                 image_font_text.font_height,
                 max_height,
+                image_font_text.letter_spacing,
                 sprite_text.scaling_mode,
             );
 

--- a/src/atlas_sprites.rs
+++ b/src/atlas_sprites.rs
@@ -348,15 +348,15 @@ fn calculate_text_width(
 
     for character in text.filtered_chars() {
         let rect = layout.textures[image_font.atlas_character_map[&character]];
-        let (width, _) =
-            compute_dimensions(
-                rect,
-                image_font_text.font_height,
-                max_height,
-                image_font_text.letter_spacing,
-                scaling_mode
-            );
-        total_width += width + Into::<f32>::into(image_font_text.letter_spacing);
+        let (width, _) = compute_dimensions(
+            rect,
+            image_font_text.font_height,
+            max_height,
+            image_font_text.letter_spacing,
+            scaling_mode,
+        );
+        let letter_spacing: f32 = image_font_text.letter_spacing.into();
+        total_width += width + letter_spacing;
     }
     total_width
 }
@@ -561,7 +561,8 @@ fn compute_dimensions(
     letter_spacing: LetterSpacing,
     scaling_mode: ScalingMode,
 ) -> (f32, f32) {
-    let width = rect.width() as f32 + Into::<f32>::into(letter_spacing);
+    let letter_spacing: f32 = letter_spacing.into();
+    let width = rect.width() as f32 + letter_spacing;
     let height = rect.height() as f32;
     let max_height = max_height as f32;
     font_height.map_or((width, height), |fh| match scaling_mode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,10 +227,10 @@ impl Default for LetterSpacing {
     }
 }
 
-impl Into<f32> for LetterSpacing {
-    fn into(self) -> f32 {
-        match self {
-            LetterSpacing::Pixel(pixels) => pixels as f32,
+impl From<LetterSpacing> for f32 {
+    fn from(spacing: LetterSpacing) -> f32 {
+        match spacing {
+            LetterSpacing::Pixel(pixels) => f32::from(pixels),
             LetterSpacing::Floating(value) => value,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,6 @@ impl Into<f32> for LetterSpacing {
     }
 }
 
-
 /// Marks any text where the underlying [`ImageFont`] asset has changed as
 /// changed, which will cause it to be re-rendered.
 #[expect(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,38 @@ pub struct ImageFontText {
     /// integer multiple of the 'native' height if you want pixel accuracy,
     /// but we allow float values for things like animations.
     pub font_height: Option<f32>,
+    /// Determines a constant kerning between characters.
+    pub letter_spacing: LetterSpacing,
 }
+
+/// How kerning between characters is specified.
+#[derive(Debug, Clone, Copy, Reflect)]
+pub enum LetterSpacing {
+    /// Kerning as an integer value, use this when you want a pixel-perfect
+    /// spacing between characters.
+    Pixel(i16),
+    /// Kerning as a floating point value, use this when you want precise
+    /// control over the spacing between characters and don't care about
+    /// pixel-perfectness.
+    Floating(f32),
+}
+
+impl Default for LetterSpacing {
+    /// Zero constant spacing between character
+    fn default() -> Self {
+        Self::Pixel(0)
+    }
+}
+
+impl Into<f32> for LetterSpacing {
+    fn into(self) -> f32 {
+        match self {
+            LetterSpacing::Pixel(pixels) => pixels as f32,
+            LetterSpacing::Floating(value) => value,
+        }
+    }
+}
+
 
 /// Marks any text where the underlying [`ImageFont`] asset has changed as
 /// changed, which will cause it to be re-rendered.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,8 +204,6 @@ pub struct ImageFontText {
     /// integer multiple of the 'native' height if you want pixel accuracy,
     /// but we allow float values for things like animations.
     pub font_height: Option<f32>,
-    /// Determines a constant kerning between characters.
-    pub letter_spacing: LetterSpacing,
 }
 
 /// How kerning between characters is specified.

--- a/src/tests/sync_texts_with_font_changes.rs
+++ b/src/tests/sync_texts_with_font_changes.rs
@@ -151,6 +151,7 @@ fn setup_app_system_state_and_entity() -> (
         text: String::from("Hello"),
         font: font_handle.clone(),
         font_height: Some(36.0),
+        letter_spacing: LetterSpacing::Pixel(0),
     });
 
     let system_state: SystemState<Query<Ref<ImageFontText>>> = SystemState::new(app.world_mut());

--- a/src/tests/sync_texts_with_font_changes.rs
+++ b/src/tests/sync_texts_with_font_changes.rs
@@ -151,7 +151,6 @@ fn setup_app_system_state_and_entity() -> (
         text: String::from("Hello"),
         font: font_handle.clone(),
         font_height: Some(36.0),
-        letter_spacing: LetterSpacing::Pixel(0),
     });
 
     let system_state: SystemState<Query<Ref<ImageFontText>>> = SystemState::new(app.world_mut());


### PR DESCRIPTION
This adds a simple API on ImageFontText to control the spacing between characters. I am unsure whether the `LetterSpacing` enum is necessary, as someone who wants pixel perfect text will likely use the `ScalingMode::Rounded` or `ScalingMode::Truncated`, which overrides the spacing no matter `LetterSpacing::Pixel` or `LetterSpacing::Floating` is chosen.

Here is `LetterSpacing::Floating(0.5)` with `ScalingMode::Smooth` on the left and `ScalingMode::Rounded` on the right:
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/ba6de59d-f2b7-41a8-a1f5-e5a726156749" />
